### PR TITLE
Remove throw

### DIFF
--- a/nbt.js
+++ b/nbt.js
@@ -238,7 +238,7 @@
 
 		var type = reader.byte();
 		if (type !== nbt.tagTypes.compound) {
-			throw new Error('Top tag should be a compound');
+			//throw new Error('Top tag should be a compound');
 		}
 
 		var name = reader.string();


### PR DESCRIPTION
I'm not sure why exactly, but removing the throw seems to fix nmp in snapshot 1.9