### PR TITLE
Fix builder list

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,10 @@ Provides a way to build complex nbt structures simply:
 const nbt = require('prismarine-nbt')
 writePlayerNbt({
   Air: nbt.short(300),
-  Armor: nbt.list(
-    nbt.comp({ Count: nbt.byte(0), Damage: nbt.short(0), Name: nbt.string("") }),
-    nbt.comp({ Count: nbt.byte(0), Damage: nbt.short(0), Name: nbt.string("") }),
-    nbt.comp({ Count: nbt.byte(0), Damage: nbt.short(0), Name: nbt.string("") }),
-  ),
+  Armor: nbt.list(nbt.comp([
+    { Count: nbt.byte(0), Damage: nbt.short(0), Name: nbt.string("") },
+    { Count: nbt.byte(0), Damage: nbt.short(0), Name: nbt.string("") },
+    { Count: nbt.byte(0), Damage: nbt.short(0), Name: nbt.string("") }
+  ])),
 })
 ```

--- a/compiler-tagname.js
+++ b/compiler-tagname.js
@@ -1,7 +1,7 @@
 /* global ctx */
 function readPString (buffer, offset) {
   const { value, size } = ctx.shortString(buffer, offset)
-  for (var c of value) {
+  for (const c of value) {
     if (c === '\0') throw new Error('unexpected tag end')
   }
   return { value, size }

--- a/nbt.js
+++ b/nbt.js
@@ -159,13 +159,13 @@ const builder = {
   short (value) { return { type: 'short', value } },
   byte (value) { return { type: 'byte', value } },
   string (value) { return { type: 'string', value } },
-  comp (value) { return { type: 'compound', value } },
+  comp (value, name='') { return { type: 'compound', name, value } },
   int (value) { return { type: 'int', value } },
   double (value) { return { type: 'double', value } },
   long (value) { return { type: 'long', value } },
-  list (...value) {
-    const type = value[0]?.type ?? 'end'
-    return { type: 'list', value: { type, value } }
+  list (value) {
+    const type = value?.type ?? 'end'
+    return { type: 'list', value: { type, value: value?.value ?? [] } }
   }
 }
 

--- a/nbt.js
+++ b/nbt.js
@@ -159,7 +159,7 @@ const builder = {
   short (value) { return { type: 'short', value } },
   byte (value) { return { type: 'byte', value } },
   string (value) { return { type: 'string', value } },
-  comp (value, name='') { return { type: 'compound', name, value } },
+  comp (value, name = '') { return { type: 'compound', name, value } },
   int (value) { return { type: 'int', value } },
   double (value) { return { type: 'double', value } },
   long (value) { return { type: 'long', value } },

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -76,5 +76,5 @@ declare module 'prismarine-nbt'{
   /**
    * @param value Takes a BigInt or an array of two 32-bit integers
    */
-  export function long<T extends number | number[] | BigInt | BigInt[]> (value: T): { type: 'long', value: T}
+  export function long<T extends number | number[number[]] | BigInt | BigInt[]> (value: T): { type: 'long', value: T}
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -76,5 +76,5 @@ declare module 'prismarine-nbt'{
   /**
    * @param value Takes a BigInt or an array of two 32-bit integers
    */
-  export function long<T extends number | number[number[]] | BigInt | BigInt[]> (value: T): { type: 'long', value: T}
+  export function long<T extends number | number[] | number[number[]] | BigInt | BigInt[]> (value: T): { type: 'long', value: T}
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -76,5 +76,5 @@ declare module 'prismarine-nbt'{
   /**
    * @param value Takes a BigInt or an array of two 32-bit integers
    */
-    export function long<T extends number | number[] | BigInt | BigInt[]> (value: T): { type: 'long', value: T}
+  export function long<T extends number | number[] | BigInt | BigInt[]> (value: T): { type: 'long', value: T}
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -66,15 +66,15 @@ declare module 'prismarine-nbt'{
   /** @deprecated */
   export function parse(data: Buffer, callback: (err: Error | null, value: NBT) => any): void;
   
-  export function short<T extends number> (val: T): { type: 'short', value: T }
-  export function byte<T extends number> (val: T): { type: 'byte', value: T }
-  export function string<T extends string> (val: T): { type: 'string', value: T }
-  export function comp<T extends object> (val: T, name?: string): { type: 'compound', name, value: T }
-  export function int<T extends number> (val: T): { type: 'int', value: T }
+  export function short<T extends number | number[]> (val: T): { type: 'short', value: T }
+  export function byte<T extends number | number[]> (val: T): { type: 'byte', value: T }
+  export function string<T extends string | string[]> (val: T): { type: 'string', value: T }
+  export function comp<T extends object | object[]> (val: T, name?: string): { type: 'compound', name, value: T }
+  export function int<T extends number | number[]> (val: T): { type: 'int', value: T }
   export function list<T extends string, K extends {type: T}>(value: K): { type: 'list'; value: { type: T | 'end', value: K } };
-  export function double<T extends number> (value: T): { type: 'double', value: T}
+  export function double<T extends number | number[]> (value: T): { type: 'double', value: T}
   /**
    * @param value Takes a BigInt or an array of two 32-bit integers
    */
-  export function long<T extends number | BigInt> (value: T[] | T): { type: 'long', value: T[] | T}
+    export function long<T extends number | number[] | BigInt | BigInt[]> (value: T): { type: 'long', value: T}
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -69,9 +69,9 @@ declare module 'prismarine-nbt'{
   export function short<T extends number> (val: T): { type: 'short', value: T }
   export function byte<T extends number> (val: T): { type: 'byte', value: T }
   export function string<T extends string> (val: T): { type: 'string', value: T }
-  export function comp<T extends object> (val: T): { type: 'compound', value: T }
+  export function comp<T extends object> (val: T, name?: string): { type: 'compound', name, value: T }
   export function int<T extends number> (val: T): { type: 'int', value: T }
-  export function list<T extends string, K extends {type: T}>(...value: K[]): { type: 'list'; value: { type: T | 'end', value: K[] } };
+  export function list<T extends string, K extends {type: T}>(value: K): { type: 'list'; value: { type: T | 'end', value: K } };
   export function double<T extends number> (value: T): { type: 'double', value: T}
   /**
    * @param value Takes a BigInt or an array of two 32-bit integers


### PR DESCRIPTION
* Fix an issue with array encoding
* Add a `name` flag to nbt.comp, which defaults to empty string `''`. This is only written if at a root level (which is `nbt` type) and is otherwise ignored
* instead of `nbt.list(nbt.number(1), nbt.number(2))` it's now `nbt.list(nbt.number([1, 2]))` to match how protodef schema works
* discussed in https://discord.com/channels/413438066984747026/413438150594265099/862357099337089024

```js
nbt.comp({
  SkullOwner: nbt.comp({
    Id: nbt.string('8987f87a-6c6b-4e87-8322-ce70957b6272'),
    Properties: nbt.comp({
      textures: nbt.list(nbt.comp([
        {
          Value: nbt.string('eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvN2VmNWY5ODY0YjM2MmI5ZWVjY2YxYWI5ZjE3YTI2NDc1OWJhMjgwZmI2NTJiZDgzZWNjMDAwNWFkMjk2ZmYzYyJ9fX0=')
        }
      ]))
    })
  })
})
``` 
produces:

<details>
  <summary>New output</summary>

```json
{
  "type": "compound",
  "name": "",
  "value": {
    "SkullOwner": {
      "type": "compound",
      "name": "",
      "value": {
        "Id": {
          "type": "string",
          "value": "8987f87a-6c6b-4e87-8322-ce70957b6272"
        },
        "Properties": {
          "type": "compound",
          "name": "",
          "value": {
            "textures": {
              "type": "list",
              "value": {
                "type": "compound",
                "value": [
                  {
                    "Value": {
                      "type": "string",
                      "value": "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvN2VmNWY5ODY0YjM2MmI5ZWVjY2YxYWI5ZjE3YTI2NDc1OWJhMjgwZmI2NTJiZDgzZWNjMDAwNWFkMjk2ZmYzYyJ9fX0="
                    }
                  }
                ]
              }
            }
          }
        }
      }
    }
  }
}
```
</details>