### PR TITLE
Fix type definition for nbt.long throwing an error

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -76,5 +76,5 @@ declare module 'prismarine-nbt'{
   /**
    * @param value Takes a BigInt or an array of two 32-bit integers
    */
-  export function long<T extends number | number[] | number[number[]] | BigInt | BigInt[]> (value: T): { type: 'long', value: T}
+  export function long<T extends number | number[] | number[][] | BigInt | BigInt[]> (value: T): { type: 'long', value: T}
 }


### PR DESCRIPTION
`number[number[]]` is an incorrect way to specify a multidimensional array and should be replaced with `number[][]` so the typescript compiler doesn't complain.