### PR TITLE
Use u16 countType for shortString

### DIFF
--- a/nbt.js
+++ b/nbt.js
@@ -3,7 +3,7 @@ const zlib = require('zlib')
 const { ProtoDefCompiler } = require('protodef').Compiler
 
 const beNbtJson = JSON.stringify(require('./nbt.json'))
-const leNbtJson = beNbtJson.replace(/([if][0-7]+)/g, 'l$1')
+const leNbtJson = beNbtJson.replace(/([iuf][0-7]+)/g, 'l$1')
 const varintJson = JSON.stringify(require('./nbt-varint.json')).replace(/([if][0-7]+)/g, 'l$1')
 
 function createProto (type) {

--- a/nbt.json
+++ b/nbt.json
@@ -5,13 +5,14 @@
   "switch": "native",
   "compound": "native",
   "i16": "native",
+  "u16": "native",
   "i32": "native",
   "i64": "native",
   "f32": "native",
   "f64": "native",
   "pstring": "native",
   "shortString": ["pstring",{
-    "countType":"i16"
+    "countType":"u16"
   }],
   "byteArray": [
     "array",


### PR DESCRIPTION
This could fix https://github.com/PrismarineJS/mineflayer/issues/2408 and https://github.com/PrismarineJS/node-minecraft-protocol/issues/974
Review required, as I'm not sure if it accidentally breaks something (that depends on signed string size).