### PR TITLE
Allow zigzag encoded varints to be read up to 64bits

### DIFF
--- a/compiler-zigzag.js
+++ b/compiler-zigzag.js
@@ -95,7 +95,7 @@ function readSignedVarInt (buffer, offset) {
       break
     }
     shift += 7 // we only have 7 bits, MSB being the return-trigger
-    if (shift > 31) throw new Error(`varint is too big: ${shift}`)
+    if (shift > 63) throw new Error(`varint is too big: ${shift}`)
   }
 
   const zigzag = ((((result << 63) >> 63) ^ result) >> 1) ^ (result & (1 << 63))


### PR DESCRIPTION
Fix https://github.com/PrismarineJS/bedrock-protocol/issues/436

readSignedVarInt is supposed to allow zigzag encoded varints up to 32bits in length. It seems some servers can incorrectly write 64bit values here which will lead to precision-related data loss, but the vanilla client allows for that data loss so I've increased the allowed assertion.