### PR TITLE
Add networked NBT (>=1.20.2)

### DIFF
--- a/nbt-network.json
+++ b/nbt-network.json
@@ -1,0 +1,113 @@
+{
+  "void": "native",
+  "container": "native",
+  "i8": "native",
+  "switch": "native",
+  "compound": "native",
+  "nbt": "native",
+  "i16": "native",
+  "u16": "native",
+  "i32": "native",
+  "i64": "native",
+  "f32": "native",
+  "f64": "native",
+  "pstring": "native",
+  "shortString": ["pstring",{
+    "countType":"u16"
+  }],
+  "byteArray": [
+    "array",
+    {
+      "countType": "i32",
+      "type": "i8"
+    }
+  ],
+  "list": [
+    "container",
+    [
+      {
+        "name": "type",
+        "type": "nbtMapper"
+      },
+      {
+        "name": "value",
+        "type": [
+          "array",
+          {
+            "countType": "i32",
+            "type": ["nbtSwitch",{"type":"type"}]
+          }
+        ]
+      }
+    ]
+  ],
+  "intArray": [
+    "array",
+    {
+      "countType": "i32",
+      "type": "i32"
+    }
+  ],
+  "longArray": [
+    "array",
+    {
+      "countType": "i32",
+      "type": "i64"
+    }
+  ],
+  "nbtMapper":["mapper",
+    {
+      "type": "i8",
+      "mappings": {
+        "0": "end",
+        "1": "byte",
+        "2": "short",
+        "3": "int",
+        "4": "long",
+        "5": "float",
+        "6": "double",
+        "7": "byteArray",
+        "8": "string",
+        "9": "list",
+        "10": "compound",
+        "11": "intArray",
+        "12": "longArray"
+      }
+    }
+  ],
+  "nbtSwitch":[
+    "switch",
+    {
+      "compareTo": "$type",
+      "fields": {
+        "end": "void",
+        "byte": "i8",
+        "short": "i16",
+        "int": "i32",
+        "long": "i64",
+        "float": "f32",
+        "double": "f64",
+        "byteArray": "byteArray",
+        "string": "shortString",
+        "list": "list",
+        "compound": "compound",
+        "nbt": "nbt",
+        "intArray": "intArray",
+        "longArray": "longArray"
+      }
+    }
+  ],
+  "nbt_network": [
+    "container",
+    [
+      {
+        "name": "type",
+        "type": "nbtMapper"
+      },
+      {
+        "name": "value",
+        "type": ["nbtSwitch",{"type":"type"}]
+      }
+    ]
+  ]
+}

--- a/nbt.js
+++ b/nbt.js
@@ -3,6 +3,7 @@ const zlib = require('zlib')
 const { ProtoDefCompiler } = require('protodef').Compiler
 
 const beNbtJson = JSON.stringify(require('./nbt.json'))
+const beNetworkNbtJson = JSON.stringify(require('./nbt-network.json'))
 const leNbtJson = beNbtJson.replace(/([iuf][0-7]+)/g, 'l$1')
 const varintJson = JSON.stringify(require('./nbt-varint.json')).replace(/([if][0-7]+)/g, 'l$1')
 
@@ -16,19 +17,24 @@ function createProto (type) {
     proto = varintJson
   } else if (type === 'little') {
     proto = leNbtJson
+  } else if (type === 'network') {
+    proto = beNetworkNbtJson
+    compiler.addTypesToCompile(JSON.parse(beNbtJson))
   }
   compiler.addTypesToCompile(JSON.parse(proto))
   return compiler.compileProtoDefSync()
 }
 
 const protoBE = createProto('big')
+const protoNetworkBE = createProto('network')
 const protoLE = createProto('little')
 const protoVarInt = createProto('littleVarint')
 
 const protos = {
   big: protoBE,
   little: protoLE,
-  littleVarint: protoVarInt
+  littleVarint: protoVarInt,
+  network: protoNetworkBE
 }
 
 function writeUncompressed (value, proto = 'big') {
@@ -236,6 +242,7 @@ module.exports = {
   parseAs,
   equal,
   proto: protoBE,
+  protoNetwork: protoNetworkBE,
   protoLE,
   protos,
   TagType: require('./typings/tag-type'),


### PR DESCRIPTION
I'm writing this PR on behalf of @xZarex.

This adds support for networked NBT introduced in version 1.20.2 or later, which is required to achieve >= 1.20.2 support for [node-minecraft-protocol](https://github.com/PrismarineJS/node-minecraft-protocol) and [mineflayer](https://github.com/PrismarineJS/mineflayer).

I have a [working fork of mineflayer](https://github.com/crux153/mineflayer/tree/mc-1.20.2) for 1.20.2 and have tested that this patch works.