### PR TITLE
Use ProtoDef `skipChecks` flag to allow full NBT array size support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ If the data is gzipped, it is automatically decompressed, for the buffer see met
 
 ### parse(data, [format]): Promise<{ parsed, type, metadata: { size, buffer? } }>
 ### parse(data, [format,] callback)
-### parse(data, format, callback, {skipChecks: boolean})
 
 Takes an optionally compressed `data` buffer and reads the nbt data.
 
@@ -56,12 +55,10 @@ try to sequentially load as big, little and little varint until the parse is suc
 Minecraft Java Edition uses big-endian format, and Bedrock uses little-endian.
 
 ### writeUncompressed(value, format='big')
-### writeUncompressed(value, format='big', {skipChecks: boolean})
 
 Returns a buffer with a serialized nbt `value`. 
 
 ### parseUncompressed(data, format='big')
-### parseUncompressed(data, format='big', {skipChecks: boolean})
 
 Takes a buffer `data` and returns a parsed nbt value.
 

--- a/README.md
+++ b/README.md
@@ -58,9 +58,17 @@ Minecraft Java Edition uses big-endian format, and Bedrock uses little-endian.
 
 Returns a buffer with a serialized nbt `value`. 
 
-### parseUncompressed(data, format='big')
+### parseUncompressed(data, format='big', options?= {noArraySizeCheck?: boolean})
 
 Takes a buffer `data` and returns a parsed nbt value.
+
+The `options` parameter is optional. When `noArraySizeCheck` is `true`, an array size check is disabled which allows for parsing of large arrays.
+
+### parseAs(data, type, options?= {noArraySizeCheck?: boolean})
+
+Takes a buffer `data` and returns a parsed nbt value. If the buffer is gzipped, it will unzip the data first.
+
+The `options` parameter is optional. When `noArraySizeCheck` is `true`, an array size check is disabled which allows for parsing of large arrays.
 
 
 ### simplify(nbt)

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ If the data is gzipped, it is automatically decompressed, for the buffer see met
 
 ### parse(data, [format]): Promise<{ parsed, type, metadata: { size, buffer? } }>
 ### parse(data, [format,] callback)
+### parse(data, format, callback, {skipChecks: boolean})
 
 Takes an optionally compressed `data` buffer and reads the nbt data.
 
@@ -55,10 +56,12 @@ try to sequentially load as big, little and little varint until the parse is suc
 Minecraft Java Edition uses big-endian format, and Bedrock uses little-endian.
 
 ### writeUncompressed(value, format='big')
+### writeUncompressed(value, format='big', {skipChecks: boolean})
 
 Returns a buffer with a serialized nbt `value`. 
 
 ### parseUncompressed(data, format='big')
+### parseUncompressed(data, format='big', {skipChecks: boolean})
 
 Takes a buffer `data` and returns a parsed nbt value.
 

--- a/nbt.js
+++ b/nbt.js
@@ -35,7 +35,7 @@ function addTypesToInterpreter (type, compiler) {
 }
 
 function createProto (type) {
-  const compiler = new ProtoDefCompiler({ skipChecks: true })
+  const compiler = new ProtoDefCompiler()
   addTypesToCompiler(type, compiler)
   return compiler.compileProtoDefSync()
 }

--- a/nbt.js
+++ b/nbt.js
@@ -175,7 +175,9 @@ function simplify (data) {
 }
 
 function setSkipChecks (value) {
-  compiler.setValue('skipChecks', value)
+  protos.big.setVariable('skipChecks', value)
+  protos.little.setVariable('skipChecks', value)
+  protos.littleVarint.setVariable('skipChecks', value)
 }
 
 function equal (nbt1, nbt2) {

--- a/nbt.js
+++ b/nbt.js
@@ -64,7 +64,7 @@ const parseProtoName = (proto) => {
 }
 
 /**
- * Return the proto object give a name and options.
+ * Return the proto object give the proto name and options.
  */
 const getProto = (proto, options = {}) => {
   const protoName = parseProtoName(proto)

--- a/nbt.js
+++ b/nbt.js
@@ -34,7 +34,7 @@ function addTypesToInterpreter (type, compiler) {
   compiler.types.nbtTagName = compiler.types.shortString
 }
 
-function createProto (type, options = {}) {
+function createProto (type, options) {
   const compiler = new ProtoDefCompiler(options)
   addTypesToCompiler(type, compiler)
   return compiler.compileProtoDefSync()
@@ -66,19 +66,19 @@ const parseProtoName = (proto) => {
 /**
  * Return the proto object give the proto name and options.
  */
-const getProto = (proto, options = {}) => {
+const getProto = (proto, options) => {
   const protoName = parseProtoName(proto)
-  if (options.skipChecks) {
+  if (options?.skipChecks) {
     return protosSkipChecks[protoName]
   }
   return protos[protoName]
 }
 
-function writeUncompressed (value, proto = 'big', options = {}) {
+function writeUncompressed (value, proto = 'big', options) {
   return getProto(proto, options).createPacketBuffer('nbt', value)
 }
 
-function parseUncompressed (data, proto = 'big', options = {}) {
+function parseUncompressed (data, proto = 'big', options) {
   return getProto(proto, options).parsePacketBuffer('nbt', data, data.startOffset).data
 }
 
@@ -92,7 +92,7 @@ const hasGzipHeader = function (data) {
 const hasBedrockLevelHeader = (data) =>
   data[1] === 0 && data[2] === 0 && data[3] === 0
 
-async function parseAs (data, type, options = {}) {
+async function parseAs (data, type, options) {
   if (hasGzipHeader(data)) {
     data = await new Promise((resolve, reject) => {
       zlib.gunzip(data, (error, uncompressed) => {
@@ -107,7 +107,7 @@ async function parseAs (data, type, options = {}) {
   return parsed
 }
 
-async function parse (data, format, callback, options = {}) {
+async function parse (data, format, callback, options) {
   let fmt = null
   if (typeof format === 'function') {
     callback = format

--- a/nbt.js
+++ b/nbt.js
@@ -58,17 +58,17 @@ function writeUncompressed (value, proto = 'big') {
 function parseUncompressed (data, proto = 'big', options = {}) {
   if (proto === true) proto = 'little'
 
-  if(options.noArraySizeCheck) {
-    protos[proto].setVariable('noArraySizeCheck', options.noArraySizeCheck);
+  if (options.noArraySizeCheck) {
+    protos[proto].setVariable('noArraySizeCheck', options.noArraySizeCheck)
   }
 
   const parsed = protos[proto].parsePacketBuffer('nbt', data, data.startOffset).data
 
   // Unset the noArraySizeCheck option so the variable value doesn't persist.
-  if(options.noArraySizeCheck) {
-    protos[proto].setVariable('noArraySizeCheck', undefined);
+  if (options.noArraySizeCheck) {
+    protos[proto].setVariable('noArraySizeCheck', undefined)
   }
-  return parsed;
+  return parsed
 }
 
 const hasGzipHeader = function (data) {
@@ -91,15 +91,15 @@ async function parseAs (data, type, options = {}) {
     })
   }
 
-  if(options.noArraySizeCheck) {
-    protos[type].setVariable('noArraySizeCheck', options.noArraySizeCheck);
+  if (options.noArraySizeCheck) {
+    protos[type].setVariable('noArraySizeCheck', options.noArraySizeCheck)
   }
 
   const parsed = protos[type].parsePacketBuffer('nbt', data, data.startOffset)
 
   // Unset the noArraySizeCheck option so the variable value doesn't persist.
-  if(options.noArraySizeCheck) {
-    protos[type].setVariable('noArraySizeCheck', undefined);
+  if (options.noArraySizeCheck) {
+    protos[type].setVariable('noArraySizeCheck', undefined)
   }
 
   parsed.metadata.buffer = data

--- a/nbt.js
+++ b/nbt.js
@@ -34,7 +34,7 @@ function addTypesToInterpreter (type, compiler) {
   compiler.types.nbtTagName = compiler.types.shortString
 }
 
-function createProto (type, options) {
+function createProto (type, options = {}) {
   const compiler = new ProtoDefCompiler(options)
   addTypesToCompiler(type, compiler)
   return compiler.compileProtoDefSync()
@@ -66,19 +66,19 @@ const parseProtoName = (proto) => {
 /**
  * Return the proto object give the proto name and options.
  */
-const getProto = (proto, options) => {
+const getProto = (proto, options = {}) => {
   const protoName = parseProtoName(proto)
-  if (options?.skipChecks) {
+  if (options.skipChecks) {
     return protosSkipChecks[protoName]
   }
   return protos[protoName]
 }
 
-function writeUncompressed (value, proto = 'big', options) {
+function writeUncompressed (value, proto = 'big', options = {}) {
   return getProto(proto, options).createPacketBuffer('nbt', value)
 }
 
-function parseUncompressed (data, proto = 'big', options) {
+function parseUncompressed (data, proto = 'big', options = {}) {
   return getProto(proto, options).parsePacketBuffer('nbt', data, data.startOffset).data
 }
 
@@ -92,7 +92,7 @@ const hasGzipHeader = function (data) {
 const hasBedrockLevelHeader = (data) =>
   data[1] === 0 && data[2] === 0 && data[3] === 0
 
-async function parseAs (data, type, options) {
+async function parseAs (data, type, options = {}) {
   if (hasGzipHeader(data)) {
     data = await new Promise((resolve, reject) => {
       zlib.gunzip(data, (error, uncompressed) => {
@@ -107,7 +107,7 @@ async function parseAs (data, type, options) {
   return parsed
 }
 
-async function parse (data, format, callback, options) {
+async function parse (data, format, callback, options = {}) {
   let fmt = null
   if (typeof format === 'function') {
     callback = format

--- a/nbt.js
+++ b/nbt.js
@@ -174,6 +174,10 @@ function simplify (data) {
   return transform(data.value, data.type)
 }
 
+function setSkipChecks (value) {
+  compiler.setValue('skipChecks', value)
+}
+
 function equal (nbt1, nbt2) {
   if (nbt1.type !== nbt2.type) return false
 
@@ -252,6 +256,7 @@ module.exports = {
   writeUncompressed,
   parseUncompressed,
   simplify,
+  setSkipChecks,
   hasBedrockLevelHeader,
   parse,
   parseAs,

--- a/nbt.js
+++ b/nbt.js
@@ -35,7 +35,7 @@ function addTypesToInterpreter (type, compiler) {
 }
 
 function createProto (type) {
-  const compiler = new ProtoDefCompiler()
+  const compiler = new ProtoDefCompiler({ skipChecks: true })
   addTypesToCompiler(type, compiler)
   return compiler.compileProtoDefSync()
 }

--- a/nbt.js
+++ b/nbt.js
@@ -59,7 +59,7 @@ function parseUncompressed (data, proto = 'big', options = {}) {
   if (proto === true) proto = 'little'
 
   protos[proto].setVariable('noArraySizeCheck', options.noArraySizeCheck)
-  
+
   return protos[proto].parsePacketBuffer('nbt', data, data.startOffset).data
 }
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "fix": "standard --fix"
   },
   "dependencies": {
-    "protodef": "^1.9.0"
+    "protodef": "bdkopen/node-protodef#add-skip-array-checks-flag"
   },
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "fix": "standard --fix"
   },
   "dependencies": {
-    "protodef": "bdkopen/node-protodef#add-skip-array-checks-flag"
+    "protodef": "^1.9.0"
   },
   "license": "MIT"
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -79,7 +79,7 @@ declare module 'prismarine-nbt'{
   }
   export function writeUncompressed(value: NBT, format?: NBTFormat): Buffer;
   export function parseUncompressed(value: Buffer, format?: NBTFormat, options?: ParseOptions): NBT;
-  export function parseAs(value: Buffer, format: NBTFormat, options?: ParseOptions): Promise<{parsed: NBT, type: NBTFormat, metadata: Metadata}>;
+  export function parseAs(value: Buffer, type: NBTFormat, options?: ParseOptions): Promise<{parsed: NBT, type: NBTFormat, metadata: Metadata}>;
   
   export function parse(data: Buffer, nbtType?: NBTFormat): Promise<{parsed: NBT, type: NBTFormat, metadata: Metadata}>;
   export function simplify(data: Tags[TagType]): any

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -64,6 +64,10 @@ declare module 'prismarine-nbt'{
     [TagType.LongArray]: LongArray;
   }
 
+  interface ParseOptions {
+    noArraySizeCheck?: boolean;
+  }
+
   export type NBTFormat = 'big' | 'little' | 'littleVarint'
 
   export type NBT = Tags['compound'] & {name: string};
@@ -74,11 +78,10 @@ declare module 'prismarine-nbt'{
     size: number
   }
   export function writeUncompressed(value: NBT, format?: NBTFormat): Buffer;
-  export function parseUncompressed(value: Buffer, format?: NBTFormat): NBT;
+  export function parseUncompressed(value: Buffer, format?: NBTFormat, options?: ParseOptions): NBT;
   
-  export function parse(data: Buffer, nbtType?: NBTFormat): Promise<{parsed: NBT, type: NBTFormat, metadata: Metadata}>;
+  export function parse(data: Buffer, nbtType?: NBTFormat, _?: never, options?: ParseOptions): Promise<{parsed: NBT, type: NBTFormat, metadata: Metadata}>;
   export function simplify(data: Tags[TagType]): any
-  export function setSkipChecks(skipChecks: boolean): void
   export function equal(nbt1: Tags[TagType], nbt2: Tags[TagType]): boolean
   // ProtoDef compiled protocols
   export const protos: { big: any, little: any, littleVarint: any };

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -82,6 +82,7 @@ declare module 'prismarine-nbt'{
   
   export function parse(data: Buffer, nbtType?: NBTFormat, options?: CompilerOptions): Promise<{parsed: NBT, type: NBTFormat, metadata: Metadata}>;
   export function simplify(data: Tags[TagType]): any
+  export function setSkipChecks(skipChecks: boolean): void
   export function equal(nbt1: Tags[TagType], nbt2: Tags[TagType]): boolean
   // ProtoDef compiled protocols
   export const protos: { big: any, little: any, littleVarint: any };

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -79,8 +79,10 @@ declare module 'prismarine-nbt'{
   }
   export function writeUncompressed(value: NBT, format?: NBTFormat, options?: CompilerOptions): Buffer;
   export function parseUncompressed(value: Buffer, format?: NBTFormat, options?: CompilerOptions): NBT;
-  
-  export function parse(data: Buffer, nbtType?: NBTFormat, options?: CompilerOptions): Promise<{parsed: NBT, type: NBTFormat, metadata: Metadata}>;
+
+  type ParseCallback = ((error: null, parsed: NBT, type: NBTFormat, metadata: Metadata) => void) | ((error: Error) => void);
+
+  export function parse(data: Buffer, nbtType?: NBTFormat, callback?: ParseCallback, options?: CompilerOptions): Promise<{parsed: NBT, type: NBTFormat, metadata: Metadata}>;
   export function simplify(data: Tags[TagType]): any
   export function equal(nbt1: Tags[TagType], nbt2: Tags[TagType]): boolean
   // ProtoDef compiled protocols

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -64,6 +64,10 @@ declare module 'prismarine-nbt'{
     [TagType.LongArray]: LongArray;
   }
 
+  interface CompilerOptions {
+    skipChecks: boolean
+  }
+
   export type NBTFormat = 'big' | 'little' | 'littleVarint'
 
   export type NBT = Tags['compound'] & {name: string};
@@ -73,10 +77,10 @@ declare module 'prismarine-nbt'{
     // The length of bytes read from the buffer
     size: number
   }
-  export function writeUncompressed(value: NBT, format?: NBTFormat): Buffer;
-  export function parseUncompressed(value: Buffer, format?: NBTFormat): NBT;
+  export function writeUncompressed(value: NBT, format?: NBTFormat, options?: CompilerOptions): Buffer;
+  export function parseUncompressed(value: Buffer, format?: NBTFormat, options?: CompilerOptions): NBT;
   
-  export function parse(data: Buffer, nbtType?: NBTFormat): Promise<{parsed: NBT, type: NBTFormat, metadata: Metadata}>;
+  export function parse(data: Buffer, nbtType?: NBTFormat, options?: CompilerOptions): Promise<{parsed: NBT, type: NBTFormat, metadata: Metadata}>;
   export function simplify(data: Tags[TagType]): any
   export function equal(nbt1: Tags[TagType], nbt2: Tags[TagType]): boolean
   // ProtoDef compiled protocols

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -79,10 +79,8 @@ declare module 'prismarine-nbt'{
   }
   export function writeUncompressed(value: NBT, format?: NBTFormat, options?: CompilerOptions): Buffer;
   export function parseUncompressed(value: Buffer, format?: NBTFormat, options?: CompilerOptions): NBT;
-
-  type ParseCallback = ((error: null, parsed: NBT, type: NBTFormat, metadata: Metadata) => void) | ((error: Error) => void);
-
-  export function parse(data: Buffer, nbtType?: NBTFormat, callback?: ParseCallback, options?: CompilerOptions): Promise<{parsed: NBT, type: NBTFormat, metadata: Metadata}>;
+  
+  export function parse(data: Buffer, nbtType?: NBTFormat, options?: CompilerOptions): Promise<{parsed: NBT, type: NBTFormat, metadata: Metadata}>;
   export function simplify(data: Tags[TagType]): any
   export function equal(nbt1: Tags[TagType], nbt2: Tags[TagType]): boolean
   // ProtoDef compiled protocols

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -64,10 +64,6 @@ declare module 'prismarine-nbt'{
     [TagType.LongArray]: LongArray;
   }
 
-  interface CompilerOptions {
-    skipChecks: boolean
-  }
-
   export type NBTFormat = 'big' | 'little' | 'littleVarint'
 
   export type NBT = Tags['compound'] & {name: string};
@@ -77,10 +73,10 @@ declare module 'prismarine-nbt'{
     // The length of bytes read from the buffer
     size: number
   }
-  export function writeUncompressed(value: NBT, format?: NBTFormat, options?: CompilerOptions): Buffer;
-  export function parseUncompressed(value: Buffer, format?: NBTFormat, options?: CompilerOptions): NBT;
+  export function writeUncompressed(value: NBT, format?: NBTFormat): Buffer;
+  export function parseUncompressed(value: Buffer, format?: NBTFormat): NBT;
   
-  export function parse(data: Buffer, nbtType?: NBTFormat, options?: CompilerOptions): Promise<{parsed: NBT, type: NBTFormat, metadata: Metadata}>;
+  export function parse(data: Buffer, nbtType?: NBTFormat): Promise<{parsed: NBT, type: NBTFormat, metadata: Metadata}>;
   export function simplify(data: Tags[TagType]): any
   export function setSkipChecks(skipChecks: boolean): void
   export function equal(nbt1: Tags[TagType], nbt2: Tags[TagType]): boolean

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -79,8 +79,9 @@ declare module 'prismarine-nbt'{
   }
   export function writeUncompressed(value: NBT, format?: NBTFormat): Buffer;
   export function parseUncompressed(value: Buffer, format?: NBTFormat, options?: ParseOptions): NBT;
+  export function parseAs(value: Buffer, format: NBTFormat, options?: ParseOptions): Promise<{parsed: NBT, type: NBTFormat, metadata: Metadata}>;
   
-  export function parse(data: Buffer, nbtType?: NBTFormat, _?: never, options?: ParseOptions): Promise<{parsed: NBT, type: NBTFormat, metadata: Metadata}>;
+  export function parse(data: Buffer, nbtType?: NBTFormat): Promise<{parsed: NBT, type: NBTFormat, metadata: Metadata}>;
   export function simplify(data: Tags[TagType]): any
   export function equal(nbt1: Tags[TagType], nbt2: Tags[TagType]): boolean
   // ProtoDef compiled protocols


### PR DESCRIPTION
NBT arrays are allowed a length up to 32 bits, so there needs to be a way to skip checks to allow full NBT support. Adding an optional object allows this to happen.

https://minecraft.wiki/w/NBT_format#Binary_format

Based on this required PR: https://github.com/ProtoDef-io/node-protodef/pull/154

Addresses: https://github.com/ProtoDef-io/node-protodef/issues/150 and https://github.com/PrismarineJS/prismarine-nbt/issues/85