### PR TITLE
fix: return type of `parseAs`

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -79,7 +79,7 @@ declare module 'prismarine-nbt'{
   }
   export function writeUncompressed(value: NBT, format?: NBTFormat): Buffer;
   export function parseUncompressed(value: Buffer, format?: NBTFormat, options?: ParseOptions): NBT;
-  export function parseAs(value: Buffer, type: NBTFormat, options?: ParseOptions): Promise<{parsed: NBT, type: NBTFormat, metadata: Metadata}>;
+  export function parseAs(value: Buffer, type: NBTFormat, options?: ParseOptions): Promise<ExtendedResults>;
   
   export function parse(data: Buffer, nbtType?: NBTFormat): Promise<{parsed: NBT, type: NBTFormat, metadata: Metadata}>;
   export function simplify(data: Tags[TagType]): any


### PR DESCRIPTION
- Fixes an incorrect return type on `parseAs`. `parseAs` calls and returns `parsePacketBuffer` from node-protodef. The return type here is actually [`ExtendedResults`](https://github.com/ProtoDef-io/node-protodef/blob/67b411aacbf9ad2ccf0aaeac0bb4d9d568b568b3/index.d.ts#L99).